### PR TITLE
fix insetting of scene view

### DIFF
--- a/Sources/Shiny.swift
+++ b/Sources/Shiny.swift
@@ -13,8 +13,7 @@ import SceneKit
 open class ShinyView: UIView {
     
     open lazy var sceneView: SceneView = {
-        let sceneView = SceneView(frame: self.bounds.insetBy(dx: -500, dy: -500))
-//        self.addSubview(sceneView) // testing
+        let sceneView = SceneView()
         self.insertSubview(sceneView, at: 0)
         return sceneView
     }()
@@ -38,6 +37,11 @@ open class ShinyView: UIView {
      The axis of the gradient. Defaults to vertical.
      */
     open var axis: Axis = .vertical
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        sceneView.frame = self.bounds
+    }
     
     /**
      Starts listening to motion updates.


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
When setting ShinyView to the frame of device, a strange inset is present on iPad:
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-12-13 at 10 58 50](https://user-images.githubusercontent.com/5944973/70825466-5286f700-1d99-11ea-9cf5-c2532d60ca8f.png)

Ran my fix on the iPad simulator which did end up rendering fine + example app still works:
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-12-13 at 11 17 28](https://user-images.githubusercontent.com/5944973/70825816-2c158b80-1d9a-11ea-909e-1f957db16d18.png)

### Description
removed the setting of scene view's frame from it's initialiser and do it in `ShinyView`'s `layoutSubviews` instead
